### PR TITLE
rtl character set currency symbols

### DIFF
--- a/numbro.js
+++ b/numbro.js
@@ -204,11 +204,11 @@
 
     // revert to number
     function unformatNumbro(n, string) {
-        var stringOriginal = string,
-            thousandRegExp,
+        var thousandRegExp,
             millionRegExp,
             billionRegExp,
             trillionRegExp,
+			currencySymbolRegExp,
             bytesMultiplier = false,
             power;
 
@@ -218,19 +218,28 @@
             if (string === zeroFormat) {
                 n._value = 0;
             } else {
+                if (cultures[currentCulture].currency.symbol !== '$') {
+                    currencySymbolRegExp = new RegExp(escapeRegExp(cultures[currentCulture].currency.symbol), 'g');
+                    string = string.replace(currencySymbolRegExp, '$');
+                }
+				
                 if (cultures[currentCulture].delimiters.decimal !== '.') {
                     string = string.replace(/\./g, '').replace(cultures[currentCulture].delimiters.decimal, '.');
                 }
 
                 // see if abbreviations are there so that we can multiply to the correct number
-                thousandRegExp = new RegExp('[^a-zA-Z]' + cultures[currentCulture].abbreviations.thousand +
-                    '(?:\\)|(\\' + cultures[currentCulture].currency.symbol + ')?(?:\\))?)?$');
-                millionRegExp = new RegExp('[^a-zA-Z]' + cultures[currentCulture].abbreviations.million +
-                    '(?:\\)|(\\' + cultures[currentCulture].currency.symbol + ')?(?:\\))?)?$');
-                billionRegExp = new RegExp('[^a-zA-Z]' + cultures[currentCulture].abbreviations.billion +
-                    '(?:\\)|(\\' + cultures[currentCulture].currency.symbol + ')?(?:\\))?)?$');
-                trillionRegExp = new RegExp('[^a-zA-Z]' + cultures[currentCulture].abbreviations.trillion +
-                    '(?:\\)|(\\' + cultures[currentCulture].currency.symbol + ')?(?:\\))?)?$');
+                thousandRegExp = new RegExp('[^a-zA-Z]' + 
+                    escapeRegExp(cultures[currentCulture].abbreviations.thousand.replace(/\./g, '')) +
+                    '(?:\\)|(\\$)?(?:\\))?)?$');
+                millionRegExp = new RegExp('[^a-zA-Z]' + 
+                    escapeRegExp(cultures[currentCulture].abbreviations.million.replace(/\./g, '')) +
+                    '(?:\\)|(\\$)?(?:\\))?)?$');
+                billionRegExp = new RegExp('[^a-zA-Z]' + 
+                    escapeRegExp(cultures[currentCulture].abbreviations.billion.replace(/\./g, '')) +
+                    '(?:\\)|(\\$)?(?:\\))?)?$');
+                trillionRegExp = new RegExp('[^a-zA-Z]' + 
+                    escapeRegExp(cultures[currentCulture].abbreviations.trillion.replace(/\./g, '')) +
+                    '(?:\\)|(\\$)?(?:\\))?)?$');
 
                 // see if bytes are there so that we can multiply to the correct number
                 for (power = 1; power < binarySuffixes.length && !bytesMultiplier; ++power) {
@@ -249,10 +258,10 @@
                 } else {
                     // do some math to create our number
                     n._value = ((bytesMultiplier) ? bytesMultiplier : 1) *
-                        ((stringOriginal.match(thousandRegExp)) ? Math.pow(10, 3) : 1) *
-                        ((stringOriginal.match(millionRegExp)) ? Math.pow(10, 6) : 1) *
-                        ((stringOriginal.match(billionRegExp)) ? Math.pow(10, 9) : 1) *
-                        ((stringOriginal.match(trillionRegExp)) ? Math.pow(10, 12) : 1) *
+                        ((string.match(thousandRegExp)) ? Math.pow(10, 3) : 1) *
+                        ((string.match(millionRegExp)) ? Math.pow(10, 6) : 1) *
+                        ((string.match(billionRegExp)) ? Math.pow(10, 9) : 1) *
+                        ((string.match(trillionRegExp)) ? Math.pow(10, 12) : 1) *
                         ((string.indexOf('%') > -1) ? 0.01 : 1) *
                         (((string.split('-').length +
                             Math.min(string.split('(').length - 1, string.split(')').length - 1)) % 2) ? 1 : -1) *
@@ -1058,6 +1067,13 @@
             ) &&
             (typeof require !== 'undefined');
     }
+	
+    /**
+     * Escape a string for use in a RegExp
+     */
+    function escapeRegExp(s) {
+        return s.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
 
     /************************************
         Floating-point helpers
@@ -1139,7 +1155,8 @@
                 mn = multiplier(next);
             return mp > mn ? mp : mn;
         }, -Infinity);
-    }
+    }	
+	
 
     /************************************
         Numbro Prototype

--- a/tests/numbro/unformat.js
+++ b/tests/numbro/unformat.js
@@ -69,6 +69,58 @@ exports.unformat = {
 
         test.done();
     },
+	
+	currencyRtl: function (test) {
+		var culture = {
+			langLocaleCode: 'unformat-rtl-test',
+			cultureCode: 'unformat-rtl-test',
+			delimiters: {
+				thousands: ',',
+				decimal: '.'
+			},
+			abbreviations: {
+				thousand: 'k',
+				million: 'm',
+				billion: 'b',
+				trillion: 't'
+			},
+			ordinal: function (number) {
+				var b = number % 10;
+				return (~~ (number % 100 / 10) === 1) ? 'th' :
+					(b === 1) ? 'st' :
+					(b === 2) ? 'nd' :
+					(b === 3) ? 'rd' : 'th';
+			},
+			currency: {
+				symbol: 'د.ت',
+				position: 'prefix'
+			},
+			defaults: {
+				currencyFormat: ',4 a'
+			},
+			formats: {
+				fourDigits: '4 a',
+				fullWithTwoDecimals: '$ ,0.00',
+				fullWithTwoDecimalsNoCurrency: ',0.00',
+				fullWithNoDecimals: '$ ,0'
+			}
+		};
+		
+		numbro.culture('unformat-rtl-test', culture);
+		numbro.setCulture('unformat-rtl-test');
+		
+		var tests = [
+			['د.ت1,234.56', 1234.56]
+		];
+		
+		test.expect(1);
+		
+        for (var i = 0; i < tests.length; i++) {
+            test.strictEqual(numbro().unformat(tests[i][0]), tests[i][1], tests[i][0]);
+        }
+
+        test.done();
+	},
 
     bytes: function (test) {
         var tests = [


### PR DESCRIPTION
I ran across a situation where I need to be able to unformat currencies that use RTL character sets for their symbols. This resolves that issue without breaking anything else. It's similar, but not identical, to the patch I made for numeral.