### PR TITLE
Removing the bom from the ko-KR language file

### DIFF
--- a/languages/ko-KR.js
+++ b/languages/ko-KR.js
@@ -1,4 +1,4 @@
-﻿/*!
+/*!
  * numbro.js language configuration
  * language : Korean
  * author (numbro.js Version): Randy Wilander : https://github.com/rocketedaway


### PR DESCRIPTION
Removing the BHOM from the language file ko-KR.js which can cause some problems in specific environments.

Fixes #296 