### PR TITLE
fix typing of numbro.languages()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ Sathit Jittanupat (https://github.com/jojosati)
 Soumik Sarkar (https://github.com/sousarka)
 Stewart Scott (https://github.com/stewart42)
 teppeis (https://github.com/teppeis)
+Tamas Nepusz (https://github.com/ntamas)
 Tetyana Kuzmenko
 Thomas Obermüller (https://github.com/thomas88)
 Tim McIntosh

--- a/numbro.d.ts
+++ b/numbro.d.ts
@@ -14,7 +14,7 @@ declare namespace numbro {
 
     export function setLanguage(tag: string, fallbackTag ?: string): void;
 
-    export function languages(): Array<NumbroLanguage>;
+    export function languages(): { [tag: string]: NumbroLanguage };
 
     export function languageData(tag ?: string): NumbroLanguage;
 


### PR DESCRIPTION
`numbro.languages()` is typed incorrectly in the TypeScript typings; in Numbro 2.x, `languages()` returns an object that maps language tags to the corresponding `NumbroLanguage` objects, but the typing claims that the function returns an array of `NumbroLanguage` objects. This pull request fixes the issue.