### PR TITLE
Enable es6 imports when using typescript

### DIFF
--- a/numbro.d.ts
+++ b/numbro.d.ts
@@ -122,4 +122,4 @@ declare namespace numbro {
     }
 }
 
-export = numbro;
+export default numbro;


### PR DESCRIPTION
In the d.ts file, numbro is being exported using `export = numbro`. In the PR that made this change, it says this is the only way to use it in typescript https://github.com/BenjaminVanRyseghem/numbro/pull/232 , and it proposes to use `import * as numbro from "numbro"` to import. However, this now causes default to be imported as a `.default` member instead. This issue https://github.com/BenjaminVanRyseghem/numbro/issues/352 explains the change in further detail.