### PR TITLE
Support options for rounding

### DIFF
--- a/src/formatting.js
+++ b/src/formatting.js
@@ -42,7 +42,8 @@ const defaultOptions = {
     thousandSeparated: false,
     spaceSeparated: false,
     negative: "sign",
-    forceSign: false
+    forceSign: false,
+    round: "round"
 };
 
 /**
@@ -458,14 +459,15 @@ function toFixedLarge(value, precision) {
  *
  * @param {number} value - number to precise
  * @param {number} precision - desired length for the mantissa
+ * @param {function} round - rounding function to be used
  * @return {string}
  */
-function toFixed(value, precision) {
+function toFixed(value, precision, round = 'round') {
     if (value.toString().indexOf("e") !== -1) {
         return toFixedLarge(value, precision);
     }
 
-    return (Math.round(+`${value}e+${precision}`) / (Math.pow(10, precision))).toFixed(precision);
+    return (Math[round](+`${value}e+${precision}`) / (Math.pow(10, precision))).toFixed(precision);
 }
 
 /**
@@ -478,12 +480,12 @@ function toFixed(value, precision) {
  * @param {boolean} trim - desired precision of the mantissa
  * @return {string}
  */
-function setMantissaPrecision(output, value, optionalMantissa, precision, trim) {
+function setMantissaPrecision(output, value, optionalMantissa, precision, trim, round) {
     if (precision === -1) {
         return output;
     }
 
-    let result = toFixed(value, precision);
+    let result = toFixed(value, precision, round);
     let [currentCharacteristic, currentMantissa = ""] = result.toString().split(".");
 
     if (currentMantissa.match(/^0+$/) && (optionalMantissa || trim)) {
@@ -700,6 +702,7 @@ function formatNumber({instance, providedFormat, state = globalState, decimalSep
     let negative = options.negative;
     let forceSign = options.forceSign;
     let exponential = options.exponential;
+    let round = options.round;
 
     let abbreviation = "";
 
@@ -730,7 +733,7 @@ function formatNumber({instance, providedFormat, state = globalState, decimalSep
         abbreviation = data.abbreviation + abbreviation;
     }
 
-    let output = setMantissaPrecision(value.toString(), value, optionalMantissa, mantissaPrecision, trimMantissa);
+    let output = setMantissaPrecision(value.toString(), value, optionalMantissa, mantissaPrecision, trimMantissa, round);
     output = setCharacteristicPrecision(output, value, optionalCharacteristic, characteristicPrecision);
     output = replaceDelimiters(output, value, thousandSeparated, state, decimalSeparator);
 

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -43,7 +43,7 @@ const defaultOptions = {
     spaceSeparated: false,
     negative: "sign",
     forceSign: false,
-    round: "round"
+    roundingFunction: Math.round
 };
 
 /**
@@ -459,15 +459,15 @@ function toFixedLarge(value, precision) {
  *
  * @param {number} value - number to precise
  * @param {number} precision - desired length for the mantissa
- * @param {function} round - rounding function to be used
+ * @param {function} roundingFunction - rounding function to be used
  * @return {string}
  */
-function toFixed(value, precision, round = "round") {
+function toFixed(value, precision, roundingFunction = Math.round) {
     if (value.toString().indexOf("e") !== -1) {
         return toFixedLarge(value, precision);
     }
 
-    return (Math[round](+`${value}e+${precision}`) / (Math.pow(10, precision))).toFixed(precision);
+    return (roundingFunction(+`${value}e+${precision}`) / (Math.pow(10, precision))).toFixed(precision);
 }
 
 /**
@@ -480,12 +480,12 @@ function toFixed(value, precision, round = "round") {
  * @param {boolean} trim - desired precision of the mantissa
  * @return {string}
  */
-function setMantissaPrecision(output, value, optionalMantissa, precision, trim, round) {
+function setMantissaPrecision(output, value, optionalMantissa, precision, trim, roundingFunction) {
     if (precision === -1) {
         return output;
     }
 
-    let result = toFixed(value, precision, round);
+    let result = toFixed(value, precision, roundingFunction);
     let [currentCharacteristic, currentMantissa = ""] = result.toString().split(".");
 
     if (currentMantissa.match(/^0+$/) && (optionalMantissa || trim)) {
@@ -702,7 +702,7 @@ function formatNumber({instance, providedFormat, state = globalState, decimalSep
     let negative = options.negative;
     let forceSign = options.forceSign;
     let exponential = options.exponential;
-    let round = options.round;
+    let roundingFunction = options.roundingFunction;
 
     let abbreviation = "";
 
@@ -733,7 +733,7 @@ function formatNumber({instance, providedFormat, state = globalState, decimalSep
         abbreviation = data.abbreviation + abbreviation;
     }
 
-    let output = setMantissaPrecision(value.toString(), value, optionalMantissa, mantissaPrecision, trimMantissa, round);
+    let output = setMantissaPrecision(value.toString(), value, optionalMantissa, mantissaPrecision, trimMantissa, roundingFunction);
     output = setCharacteristicPrecision(output, value, optionalCharacteristic, characteristicPrecision);
     output = replaceDelimiters(output, value, thousandSeparated, state, decimalSeparator);
 

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -462,7 +462,7 @@ function toFixedLarge(value, precision) {
  * @param {function} round - rounding function to be used
  * @return {string}
  */
-function toFixed(value, precision, round = 'round') {
+function toFixed(value, precision, round = "round") {
     if (value.toString().indexOf("e") !== -1) {
         return toFixedLarge(value, precision);
     }

--- a/src/validating.js
+++ b/src/validating.js
@@ -91,12 +91,6 @@ const validBaseValues = [
     "general"
 ];
 
-const validRoundValues = [
-    "round",
-    "ceil",
-    "floor"
-];
-
 const validFormat = {
     output: {
         type: "string",
@@ -146,10 +140,7 @@ const validFormat = {
     },
     optionalMantissa: "boolean",
     trimMantissa: "boolean",
-    round: {
-        type: "string",
-        validValues: validRoundValues
-    },
+    roundingFunction: "function",
     optionalCharacteristic: "boolean",
     thousandSeparated: "boolean",
     spaceSeparated: "boolean",

--- a/src/validating.js
+++ b/src/validating.js
@@ -91,6 +91,12 @@ const validBaseValues = [
     "general"
 ];
 
+const validRoundValues = [
+    "round",
+    "ceil",
+    "floor"
+];
+
 const validFormat = {
     output: {
         type: "string",
@@ -140,6 +146,10 @@ const validFormat = {
     },
     optionalMantissa: "boolean",
     trimMantissa: "boolean",
+    round: {
+        type: "string",
+        validValues: validRoundValues
+    },
     optionalCharacteristic: "boolean",
     thousandSeparated: "boolean",
     spaceSeparated: "boolean",

--- a/tests/src/numbro-tests.js
+++ b/tests/src/numbro-tests.js
@@ -348,5 +348,30 @@ describe("numbro", () => {
             expect(numbro(1.2345).format(options)).toBe("1.2345");
             expect(numbro(1.23456).format(options)).toBe("1.2346");
         });
+
+        it("Issue #364", () => {
+            let options = {
+                mantissa: 2,
+                trimMantissa: true
+            };
+
+            expect(numbro(1.23).format(options)).toBe("1.23");
+            expect(numbro(1.234).format(options)).toBe("1.23");
+            expect(numbro(1.235).format(options)).toBe("1.24");
+            expect(numbro(1.236).format(options)).toBe("1.24");
+
+
+            options.round = 'floor';
+            expect(numbro(1.23).format(options)).toBe("1.23");
+            expect(numbro(1.234).format(options)).toBe("1.23");
+            expect(numbro(1.235).format(options)).toBe("1.23");
+            expect(numbro(1.236).format(options)).toBe("1.23");
+
+            options.round = 'ceil';
+            expect(numbro(1.23).format(options)).toBe("1.23");
+            expect(numbro(1.234).format(options)).toBe("1.24");
+            expect(numbro(1.235).format(options)).toBe("1.24");
+            expect(numbro(1.236).format(options)).toBe("1.24");
+        });
     });
 });

--- a/tests/src/numbro-tests.js
+++ b/tests/src/numbro-tests.js
@@ -361,13 +361,13 @@ describe("numbro", () => {
             expect(numbro(1.236).format(options)).toBe("1.24");
 
 
-            options.round = "floor";
+            options.roundingFunction = Math.floor;
             expect(numbro(1.23).format(options)).toBe("1.23");
             expect(numbro(1.234).format(options)).toBe("1.23");
             expect(numbro(1.235).format(options)).toBe("1.23");
             expect(numbro(1.236).format(options)).toBe("1.23");
 
-            options.round = "ceil";
+            options.roundingFunction = Math.ceil;
             expect(numbro(1.23).format(options)).toBe("1.23");
             expect(numbro(1.234).format(options)).toBe("1.24");
             expect(numbro(1.235).format(options)).toBe("1.24");

--- a/tests/src/numbro-tests.js
+++ b/tests/src/numbro-tests.js
@@ -361,13 +361,13 @@ describe("numbro", () => {
             expect(numbro(1.236).format(options)).toBe("1.24");
 
 
-            options.round = 'floor';
+            options.round = "floor";
             expect(numbro(1.23).format(options)).toBe("1.23");
             expect(numbro(1.234).format(options)).toBe("1.23");
             expect(numbro(1.235).format(options)).toBe("1.23");
             expect(numbro(1.236).format(options)).toBe("1.23");
 
-            options.round = 'ceil';
+            options.round = "ceil";
             expect(numbro(1.23).format(options)).toBe("1.23");
             expect(numbro(1.234).format(options)).toBe("1.24");
             expect(numbro(1.235).format(options)).toBe("1.24");


### PR DESCRIPTION
Added fixed options for rounding non-large/small numbers as follows:
'round'
'ceil'
'floor'

Resolves #364.

Hope this helps!