### PR TITLE
fix for #392: Small negative numbers get the leading zero incorrectly cut off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Next
+- Fix #392: Small negative numbers get the leading zero incorrectly cut off
+
 ### 2.1.2
 
 - Fix #399: Update dependencies. Thanks @baer

--- a/src/formatting.js
+++ b/src/formatting.js
@@ -572,10 +572,11 @@ function replaceDelimiters(output, value, thousandSeparated, state, decimalSepar
     let result = output.toString();
     let characteristic = result.split(".")[0];
     let mantissa = result.split(".")[1];
+    const hasNegativeSign = value < 0 && characteristic.indexOf("-") === 0;
 
     if (thousandSeparated) {
-        if (value < 0) {
-            // Remove the minus sign
+        if (hasNegativeSign) {
+            // Remove the negative sign
             characteristic = characteristic.slice(1);
         }
 
@@ -584,8 +585,8 @@ function replaceDelimiters(output, value, thousandSeparated, state, decimalSepar
             characteristic = characteristic.slice(0, position + index) + thousandSeparator + characteristic.slice(position + index);
         });
 
-        if (value < 0) {
-            // Add back the minus sign
+        if (hasNegativeSign) {
+            // Add back the negative sign
             characteristic = `-${characteristic}`;
         }
     }

--- a/tests/src/formatting-tests.js
+++ b/tests/src/formatting-tests.js
@@ -2468,6 +2468,19 @@ describe("formatting", () => {
                         undefined
                     ]
                     , "12.23"
+                ],
+                [
+                    [
+                        -0.001223, {
+                        mantissa: 2,
+                        trimMantissa: false,
+                        thousandSeparated: true
+                    },
+                        globalState,
+                        undefined,
+                        undefined
+                    ]
+                    , "0.00"
                 ]
             ];
 


### PR DESCRIPTION
A number like 
`-0.00490`
formatted with 
`mantissa:2, trimMantissa: false, thousandSeparated: true`
now correctly outputs:
`0.00`

Fixes #392
