### PR TITLE
Fix crash when manipulating repeating decimals like 1/3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2017,9 +2017,9 @@
       }
     },
     "bignumber.js": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
-      "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg=="
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.0.1.tgz",
+      "integrity": "sha512-zAySveTJXkgLYCBi0b14xzfnOs+f3G6x36I8w2a1+PFQpWk/dp0mI0F+ZZK2bu+3ELewDcSyP+Cfq++NcHX7sg=="
     },
     "binary-extensions": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,6 @@
     "dist"
   ],
   "dependencies": {
-    "bignumber.js": "^4.0.4"
+    "bignumber.js": "^8.0.1"
   }
 }

--- a/src/manipulating.js
+++ b/src/manipulating.js
@@ -40,7 +40,7 @@ function add(n, other, numbro) {
 
     otherValue = new BigNumber(otherValue);
 
-    n._value = value.add(otherValue).toNumber();
+    n._value = value.plus(otherValue).toNumber();
     return n;
 }
 

--- a/tests/src/manipulating-tests.js
+++ b/tests/src/manipulating-tests.js
@@ -35,7 +35,7 @@ describe("manipulating", () => {
     });
 
 
-    describe("add", () => {
+    describe.only("add", () => {
         it("works with numbers", () => {
             let data = [
                 // [value, other, expectedOutput]

--- a/tests/src/manipulating-tests.js
+++ b/tests/src/manipulating-tests.js
@@ -35,7 +35,7 @@ describe("manipulating", () => {
     });
 
 
-    describe.only("add", () => {
+    describe("add", () => {
         it("works with numbers", () => {
             let data = [
                 // [value, other, expectedOutput]

--- a/tests/src/manipulating-tests.js
+++ b/tests/src/manipulating-tests.js
@@ -162,6 +162,13 @@ describe("manipulating", () => {
                 expect(result._value).toBe(expectedOutput);
             });
         });
+
+        it("works with repeating decimals", () => {
+            numbroStub.isNumbro.and.returnValue(true);
+            let instance = numbroStub(1/3);
+            let result = manipulating.multiply(instance, numbroStub(1));
+            expect(result._value).toBe(0.3333333333333333);
+        });
     });
 
     describe("divide", () => {


### PR DESCRIPTION
## Problem

Numbro crashes when manipulating numbers containing repeating decimals

## Reproduction

```js
numbro(1/3).multiply(1)
```

_Note:_ The last commit is a test that would fail on master to demonstrate this problem.

## Solution

The version of Bignumber.js that numbro currently relies on ([v4.0.4](https://github.com/MikeMcl/bignumber.js/releases/tag/v4.0.4)) requires a `round()` method to deal with numbers that have repeating decimals.  As of [v6.0](https://github.com/MikeMcl/bignumber.js/blob/master/CHANGELOG.md#600) Bignumber.js removed `round()` and added this functionality into the core of the library.

Given that, you could either:
* Add round to all call sites using arithmetic
* Update Bignumber.js to the latest version

This PR is the 2nd of these two choices since there is really no reason to stay 4 major revs back on a core dependency. 

_Note:_ Bignumber.js [v6.0](https://github.com/MikeMcl/bignumber.js/blob/master/CHANGELOG.md#600) removed the alias `add`. To update the lib I had to update the `manipulating.js` file to replace `x.add()` with `x.plus()`.