### PR TITLE
Use regular functions in language files for IE11

### DIFF
--- a/languages/bg.js
+++ b/languages/bg.js
@@ -16,7 +16,9 @@ module.exports = {
         billion: "M",
         trillion: "T"
     },
-    ordinal: () => ".",
+    ordinal: function() {
+        return "."
+    },
     currency: {
         symbol: "лв.",
         code: "BGN"

--- a/languages/en-AU.js
+++ b/languages/en-AU.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         let b = number % 10;
         return (~~(number % 100 / 10) === 1) ? "th" : (b === 1) ? "st" : (b === 2) ? "nd" : (b === 3) ? "rd" : "th";
     },

--- a/languages/en-GB.js
+++ b/languages/en-GB.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         let b = number % 10;
         return (~~(number % 100 / 10) === 1) ? "th" : (b === 1) ? "st" : (b === 2) ? "nd" : (b === 3) ? "rd" : "th";
     },

--- a/languages/en-IE.js
+++ b/languages/en-IE.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         let b = number % 10;
         return (~~(number % 100 / 10) === 1) ? "th" : (b === 1) ? "st" : (b === 2) ? "nd" : (b === 3) ? "rd" : "th";
     },

--- a/languages/en-NZ.js
+++ b/languages/en-NZ.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         let b = number % 10;
         return (~~(number % 100 / 10) === 1) ? "th" : (b === 1) ? "st" : (b === 2) ? "nd" : (b === 3) ? "rd" : "th";
     },

--- a/languages/en-ZA.js
+++ b/languages/en-ZA.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         let b = number % 10;
         return (~~(number % 100 / 10) === 1) ? "th" : (b === 1) ? "st" : (b === 2) ? "nd" : (b === 3) ? "rd" : "th";
     },

--- a/languages/es-AR.js
+++ b/languages/es-AR.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-CL.js
+++ b/languages/es-CL.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-CO.js
+++ b/languages/es-CO.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-CR.js
+++ b/languages/es-CR.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-ES.js
+++ b/languages/es-ES.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-NI.js
+++ b/languages/es-NI.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-PE.js
+++ b/languages/es-PE.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-PR.js
+++ b/languages/es-PR.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/es-SV.js
+++ b/languages/es-SV.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
     },

--- a/languages/fil-PH.js
+++ b/languages/fil-PH.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let b = number % 10;
         return (~~(number % 100 / 10) === 1) ? "th" : (b === 1) ? "st" : (b === 2) ? "nd" : (b === 3) ? "rd" : "th";
     },

--- a/languages/fr-CA.js
+++ b/languages/fr-CA.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "G",
         trillion: "T"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         return number === 1 ? "er" : "ème";
     },
     spaceSeparated: true,

--- a/languages/fr-CH.js
+++ b/languages/fr-CH.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         return number === 1 ? "er" : "ème";
     },
     currency: {

--- a/languages/fr-FR.js
+++ b/languages/fr-FR.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         return number === 1 ? "er" : "ème";
     },
     currency: {

--- a/languages/he-IL.js
+++ b/languages/he-IL.js
@@ -22,7 +22,9 @@ module.exports = {
         position: "prefix",
         code: "ILS"
     },
-    ordinal: () => "",
+    ordinal: function() {
+        return ""
+    },
     currencyFormat: {
         thousandSeparated: true,
         totalLength: 4,

--- a/languages/nb-NO.js
+++ b/languages/nb-NO.js
@@ -17,7 +17,9 @@ module.exports = {
         billion: "md",
         trillion: "b"
     },
-    ordinal: () => "",
+    ordinal: function() {
+        return ""
+    },
     currency: {
         symbol: "kr",
         position: "postfix",

--- a/languages/nl-BE.js
+++ b/languages/nl-BE.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "mld",
         trillion: "bln"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         let remainder = number % 100;
         return (number !== 0 && remainder <= 1 || remainder === 8 || remainder >= 20) ? "ste" : "de";
     },

--- a/languages/nl-NL.js
+++ b/languages/nl-NL.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "mrd",
         trillion: "bln"
     },
-    ordinal: (number) => {
+    ordinal: function(number) {
         let remainder = number % 100;
         return (number !== 0 && remainder <= 1 || remainder === 8 || remainder >= 20) ? "ste" : "de";
     },

--- a/languages/pl-PL.js
+++ b/languages/pl-PL.js
@@ -17,7 +17,9 @@ module.exports = {
         billion: "mld",
         trillion: "bln"
     },
-    ordinal: () => ".",
+    ordinal: function() {
+        return "."
+    },
     currency: {
         symbol: " zł",
         position: "postfix",

--- a/languages/sr-Cyrl-RS.js
+++ b/languages/sr-Cyrl-RS.js
@@ -17,7 +17,9 @@ module.exports = {
         billion: "b",
         trillion: "t"
     },
-    ordinal: () => ".",
+    ordinal: function() {
+        return "."
+    },
     currency: {
         symbol: "RSD",
         code: "RSD"

--- a/languages/sv-SE.js
+++ b/languages/sv-SE.js
@@ -17,7 +17,9 @@ module.exports = {
         billion: "md",
         trillion: "tmd"
     },
-    ordinal: () => "",
+    ordinal: function() {
+        return ""
+    },
     currency: {
         symbol: "kr",
         position: "postfix",

--- a/languages/tr-TR.js
+++ b/languages/tr-TR.js
@@ -45,7 +45,7 @@ module.exports = {
         billion: "milyar",
         trillion: "trilyon"
     },
-    ordinal: number => {
+    ordinal: function(number) {
         // special case for zero
         if (number === 0) {
             return "'ıncı";

--- a/languages/uk-UA.js
+++ b/languages/uk-UA.js
@@ -17,7 +17,7 @@ module.exports = {
         billion: "млрд",
         trillion: "блн"
     },
-    ordinal: () => {
+    ordinal: function() {
         // not ideal, but since in Ukrainian it can taken on
         // different forms (masculine, feminine, neuter)
         // this is all we can do


### PR DESCRIPTION
In environments that don't compile node_modules, some language files used to break in older browsers which don't support arrow functions (e.g. IE11 and older). Thus replacing all arrow with regular functions.