### PR TITLE
update numbro.d.ts

### DIFF
--- a/numbro.d.ts
+++ b/numbro.d.ts
@@ -138,4 +138,4 @@ declare namespace numbro {
     }
 }
 
-export default numbro;
+export = numbro;


### PR DESCRIPTION
change `export default numbro` to `export = numbro` so that the typescript can correctly handle the namespace.
Fixes  #403 