### PR TITLE
Fix coverage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,6 +7,7 @@ Anatoli Papirovski (https://github.com/apapirovski)
 Andrei Alecu https://github.com/andreialecu
 Anna Osipova (https://github.com/anna-osipova)
 Antoine Vadot (https://github.com/T0nio)
+Austin Greco (https://github.com/austingreco)
 badplum (https://github.com/badplum)
 Benedikt Huss (https://github.com/ben305)
 Benjamin Van Ryseghem <benjamin@vanryseghem.com> (https://benjamin.vanryseghem.com)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Bump `lodash.template` to 4.5.0
 - Fix #359: Add Bytes I18N possibility + French translation
+- Fix #474: Fix Bytes formatting tests and coverage
 
 ### 2.2.0
 

--- a/src/validating.js
+++ b/src/validating.js
@@ -186,6 +186,13 @@ const validLanguage = {
         type: "function",
         mandatory: true
     },
+    bytes: {
+        type: "object",
+        children: {
+            binarySuffixes: "object",
+            decimalSuffixes: "object"
+        }
+    },
     currency: {
         type: "object",
         children: {

--- a/tests/languages/fr-FR-tests.js
+++ b/tests/languages/fr-FR-tests.js
@@ -54,18 +54,18 @@ describe("fr-FR", () => {
     it("formats bytes correctly", () => {
         let data = [
             [100, { output: "byte", base: "decimal" }, "100o"],
-            [2048, { output: "byte", base: "decimal" }, "2Ko"],
-            [7884486213, { output: "byte", base: "decimal", mantissa: 1 }, "7.3Go"],
-            [3467479682787, { output: "byte", base: "decimal", mantissa: 1 }, "3.154To"],
+            [2048, { output: "byte", base: "decimal" }, "2,048Ko"],
+            [7884486213, { output: "byte", base: "decimal", mantissa: 1 }, "7,9Go"],
+            [3467479682787, { output: "byte", base: "decimal", mantissa: 1 }, "3,5To"],
             [100, { output: "byte", base: "binary" }, "100o"],
             [2048, { output: "byte", base: "binary" }, "2Kio"],
-            [7884486213, { output: "byte", base: "binary", mantissa: 1 }, "7.3Gio"],
-            [3467479682787, { output: "byte", base: "binary", mantissa: 1 }, "3.154Tio"]
+            [7884486213, { output: "byte", base: "binary", mantissa: 1 }, "7,3Gio"],
+            [3467479682787, { output: "byte", base: "binary", mantissa: 1 }, "3,2Tio"]
         ];
 
         data.forEach(([input, format, expectedResult]) => {
             let result = numbro(input).format(format);
-            expect(result).toBe(expectedResult, `Should format bytes correctly ${input} with ${format}`);
+            expect(result).toBe(expectedResult, `Should format bytes correctly ${input} with ${format.base}`);
         });
     });
 

--- a/tests/src/formatting-tests.js
+++ b/tests/src/formatting-tests.js
@@ -383,8 +383,9 @@ describe("formatting", () => {
                 let format = {base: "general"};
                 let value = jasmine.createSpy("value");
                 let n = numbroStub(value);
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({});
+                state.currentBytes.and.returnValue(bytes.general.suffixes);
                 getFormatByteUnits.and.returnValue({});
 
                 formatByte(n, format, state, numbroStub);
@@ -401,8 +402,11 @@ describe("formatting", () => {
                 let format = {base: "general"};
                 let value = jasmine.createSpy("value");
                 let instance = numbroStub(value);
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({});
+                state.currentBytes.and.returnValue({
+                    decimalSuffixes: bytes.general.suffixes
+                });
                 getFormatByteUnits.and.returnValue({});
 
                 formatByte(instance, format, state, numbroStub);
@@ -414,8 +418,11 @@ describe("formatting", () => {
                 let format = {base: "binary"};
                 let value = jasmine.createSpy("value");
                 let n = numbroStub(value);
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({});
+                state.currentBytes.and.returnValue({
+                    binarySuffixes: bytes.binary.suffixes
+                });
                 getFormatByteUnits.and.returnValue({});
 
                 formatByte(n, format, state, numbroStub);
@@ -427,8 +434,11 @@ describe("formatting", () => {
                 let format = {base: "decimal"};
                 let value = jasmine.createSpy("value");
                 let n = numbroStub(value);
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({});
+                state.currentBytes.and.returnValue({
+                    decimalSuffixes: bytes.general.suffixes
+                });
                 getFormatByteUnits.and.returnValue({});
 
                 formatByte(n, format, state, numbroStub);
@@ -440,8 +450,11 @@ describe("formatting", () => {
                 let format = {base: undefined};
                 let value = jasmine.createSpy("value");
                 let n = numbroStub(value);
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({});
+                state.currentBytes.and.returnValue({
+                    binarySuffixes: bytes.binary.suffixes
+                });
                 getFormatByteUnits.and.returnValue({});
 
                 formatByte(n, format, state, numbroStub);
@@ -451,8 +464,11 @@ describe("formatting", () => {
 
             it("separates the suffix with a space when `spaced` flag is true", () => {
                 let instance = jasmine.createSpy("instance");
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({spaced: true});
+                state.currentBytes.and.returnValue({
+                    binarySuffixes: bytes.binary.suffixes
+                });
                 getFormatByteUnits.and.returnValue({suffix: "B"});
                 formatNumber.and.returnValue("2");
 
@@ -462,8 +478,11 @@ describe("formatting", () => {
 
             it("does not separate the suffix with a space when `spaced` flag is false", () => {
                 let instance = jasmine.createSpy("instance");
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({spaced: false});
+                state.currentBytes.and.returnValue({
+                    binarySuffixes: bytes.binary.suffixes
+                });
                 getFormatByteUnits.and.returnValue({suffix: "B"});
                 formatNumber.and.returnValue("2");
 
@@ -473,8 +492,11 @@ describe("formatting", () => {
 
             it("appends the suffix at the end", () => {
                 let instance = jasmine.createSpy("instance");
-                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations"]);
+                let state = jasmine.createSpyObj("state", ["currentByteDefaultFormat", "currentAbbreviations", "currentBytes"]);
                 state.currentAbbreviations.and.returnValue({});
+                state.currentBytes.and.returnValue({
+                    binarySuffixes: bytes.binary.suffixes
+                });
                 getFormatByteUnits.and.returnValue({suffix: "B"});
                 formatNumber.and.returnValue("2");
 


### PR DESCRIPTION
This fixes the errors when running `npm run coverage`, but does not address `npm test` always passing even with failing tests.

Issue #474 