### PR TITLE
Add support for negative time durations

### DIFF
--- a/src/formatting.js
+++ b/src/formatting.js
@@ -237,10 +237,23 @@ function formatOrdinal(instance, providedFormat, state) {
  * @return {string}
  */
 function formatTime(instance) {
-    let hours = Math.floor(instance._value / 60 / 60);
-    let minutes = Math.floor((instance._value - (hours * 60 * 60)) / 60);
-    let seconds = Math.round(instance._value - (hours * 60 * 60) - (minutes * 60));
-    return `${hours}:${(minutes < 10) ? "0" : ""}${minutes}:${(seconds < 10) ? "0" : ""}${seconds}`;
+    let options = Object.assign({}, defaultOptions, providedFormat);
+    
+    let hours = Math.floor(Math.abs(instance._value) / 60 / 60);
+    let minutes = Math.floor((Math.abs(instance._value) - (hours * 60 * 60)) / 60);
+    let seconds = Math.round(Math.abs(instance._value) - (hours * 60 * 60) - (minutes * 60));
+    
+    let absoluteTime = `${hours}:${(minutes < 10) ? "0" : ""}${minutes}:${(seconds < 10) ? "0" : ""}${seconds}`;
+    
+    if (instance._value < 0 && options.negative === "sign") {
+        return `-${absoluteTime}`;
+    } else if (instance._value < 0 && options.negative === "parenthesis") {
+        return `(${absoluteTime})`;
+    } else if (instance._value > 0 && options.forceSign) {
+        return `+${absoluteTime}`;
+    } else {
+        return absoluteTime;
+    }
 }
 
 /**


### PR DESCRIPTION
This functionality is missing from moment-js as well as incorrect in numbro.

Use case is I want to format difference between two durations of time, which might be negative. E.g. my 100m sprint is 5 sec less than avg so my offset from avg would be displayed as -0:00:05.