### PR TITLE
fix unformat return type

### DIFF
--- a/numbro.d.ts
+++ b/numbro.d.ts
@@ -30,7 +30,7 @@ declare namespace numbro {
 
     export function loadLanguagesInNode(): void;
 
-    export function unformat(input: string, format?: Format | string): number;
+    export function unformat(input: string, format?: Format | string): number | undefined;
 
     interface Numbro {
         clone(): Numbro;


### PR DESCRIPTION
https://github.com/BenjaminVanRyseghem/numbro/blob/develop/src/unformatting.js#L253-L282

The return value type of unformat is just number, which is not accurate because it is possible to return undefined.