### PR TITLE
Update million abbreviation for es-AR language

### DIFF
--- a/languages/es-AR.js
+++ b/languages/es-AR.js
@@ -13,7 +13,7 @@ module.exports = {
     },
     abbreviations: {
         thousand: "k",
-        million: "mm",
+        million: "m",
         billion: "b",
         trillion: "t"
     },


### PR DESCRIPTION
Not sure why the current abbreviation for million for es-AR is set to "mm". I'm from Argentina so spanish is my native tongue. I believe it's more accurate to just use a single "m".

Also, using "mm" could lead to reading it as "mil millones" which means "thousand millions".