### PR TITLE
Update es-es locale abbr and ordinal translations

### DIFF
--- a/languages/es-ES.js
+++ b/languages/es-ES.js
@@ -12,14 +12,13 @@ module.exports = {
         decimal: ","
     },
     abbreviations: {
-        thousand: "k",
-        million: "mm",
-        billion: "b",
-        trillion: "t"
+        thousand: "K",
+        million: "M",
+        billion: "MM",
+        trillion: "B"
     },
     ordinal: (number) => {
-        let b = number % 10;
-        return (b === 1 || b === 3) ? "er" : (b === 2) ? "do" : (b === 7 || b === 0) ? "mo" : (b === 8) ? "vo" : (b === 9) ? "no" : "to";
+        return '.º';
     },
     currency: {
         symbol: "€",


### PR DESCRIPTION
This was wrong from a strict point of view for a spanish speaker in Spain.

For abbreviations, this change is as close as we could get without changing the implementation. For Spain based speakers, 1000 is K (mil), 1_000_000 is M (un millón), 1_000_000_000 is 'a thousand millions' (MM, or mil millones) and 1_000_000_000_000 is B (un billón) which I believe is totally ankward for an English speaker. Additionally, uppercase abbreviations are far more common in Spain.

Some references about abbreviations:
https://dle.rae.es/bill%C3%B3n
https://dle.rae.es/trill%C3%B3n
https://www.fundeu.es/consulta/abreviatura-o-simbolo-de-millon-21248/

For the ordinal function change, see that there is no official ordinal forms based in number-string except the '.º' expression (at least in Spain this form is much more common). See:
https://www.wikilengua.org/index.php/N%C3%BAmero_ordinal