### PR TITLE
add a function for min_max_mantissa

### DIFF
--- a/src/formatting.js
+++ b/src/formatting.js
@@ -824,6 +824,17 @@ function formatOrDefault(providedFormat, defaultFormat) {
     return providedFormat;
 }
 
+function correctFloatFormat(num, min, max) {
+    dec_str = num.toString().split('.')[1]
+    dec_num = dec_str.length
+    if (dec_num < min) {
+        dec_num = min
+    } else if (dec_num > max) {
+        dec_num = max
+    };
+    return num.toFixed(dec_num)
+}
+
 module.exports = (numbro) => ({
     format: (...args) => format(...args, numbro),
     getByteUnit: (...args) => getByteUnit(...args, numbro),


### PR DESCRIPTION
Fixes #609 

I just create a function in formatting.js file.
You must pass three inputs:
- num: desired number
- min: minimum number of decimal
- max: maximum number of decimal

And then you will get your output.

For example:

let num = 12.345678
console.log(correct_float_format(num, 2, 4));

output will be: 12.3456

* To fix this issue i just used a trick and converted the number to string and then used .split function to get the number of decimal.
