### PR TITLE
add getting significant number feature

### DIFF
--- a/src/formatting.js
+++ b/src/formatting.js
@@ -824,6 +824,10 @@ function formatOrDefault(providedFormat, defaultFormat) {
     return providedFormat;
 }
 
+function precise(num, significant) {
+    return num.toPrecision(significant);
+}
+
 module.exports = (numbro) => ({
     format: (...args) => format(...args, numbro),
     getByteUnit: (...args) => getByteUnit(...args, numbro),


### PR DESCRIPTION
Fixes #407 

I created a function named precise. Just pass the number and significant to get your desired output.

Example:
let num = 0.000012203000
console.log(precise(num, 2))

output: 0.000012