### PR TITLE
fix issue #472: provide rounding with input format function

### DIFF
--- a/src/formatting.js
+++ b/src/formatting.js
@@ -824,6 +824,12 @@ function formatOrDefault(providedFormat, defaultFormat) {
     return providedFormat;
 }
 
+function round(num, format) {
+    pow = format.replace('%', '').split('.')[1].length
+    ans =  Math.round((num + Number.EPSILON) * (10 ** pow)) / (10 ** pow)
+    return ans.toFixed(pow) + '%'
+}
+
 module.exports = (numbro) => ({
     format: (...args) => format(...args, numbro),
     getByteUnit: (...args) => getByteUnit(...args, numbro),


### PR DESCRIPTION
Fixes #472 

I just provide a function for rounding in the desired format.
Pass a number and a format like "0,0.00%" to it and get the output.

example:
console.log(round(1.0005, '0,0.000%'))
output: 1.001%